### PR TITLE
Use specified authManager DB rather than default in search model

### DIFF
--- a/models/Search.php
+++ b/models/Search.php
@@ -69,7 +69,7 @@ class Search extends Model
                 ->andFilterWhere(['like', 'rule_name', $this->rule_name]);
         }
         
-        $dataProvider->allModels = $query->all();
+        $dataProvider->allModels = $query->all($this->manager->db);
         
         return $dataProvider;
     }


### PR DESCRIPTION
Alter search query to use database connection specified in $this->manager->db (globally in \Yii::$app->authManager) rather than default database