### PR TITLE
Less restrictive AuthItem name match regex

### DIFF
--- a/models/AuthItem.php
+++ b/models/AuthItem.php
@@ -78,7 +78,7 @@ abstract class AuthItem extends Model
     {
         return [
             ['name', 'required'],
-            ['name', 'match', 'pattern' => '/^[\w-]+$/'],
+            ['name', 'match', 'pattern' => '/^[a-z0-9]{2}[a-z0-9.]{0,}[a-z0-9]{1}+$/'],
             [['name', 'description', 'rule'], 'trim'],
             ['name', function () {
                 if ($this->manager->getItem($this->name) !== null) {

--- a/models/AuthItem.php
+++ b/models/AuthItem.php
@@ -78,7 +78,7 @@ abstract class AuthItem extends Model
     {
         return [
             ['name', 'required'],
-            ['name', 'match', 'pattern' => '/^[a-z0-9]{2}[a-z0-9.]{0,}[a-z0-9]{1}+$/'],
+            ['name', 'match', 'pattern' => '/^[a-zA-Z0-9]{2}[a-z0-9._]{0,}[a-zA-Z0-9]{1}+$/'],
             [['name', 'description', 'rule'], 'trim'],
             ['name', function () {
                 if ($this->manager->getItem($this->name) !== null) {


### PR DESCRIPTION
I could not use project.create as a permission name, so I changed the name match rule to be less restrictive.

Now you can create names with a dot or an underscore and with mixed case letters, but no funny characters and no spaces.

Since a dot in the middle of rbac permission names is wildly common, I suggest that this be merged into main repository because it seems to be a unnecessary restriction.