### PR TITLE
Bootstrap.php:Ensure DbManager properties are kept

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -33,7 +33,7 @@ class Bootstrap implements BootstrapInterface
         // register translations
         if (!isset($app->get('i18n')->translations['rbac*'])) {
             $app->get('i18n')->translations['rbac*'] = [
-                'class'    => 'yii\i18n\PhpMessageSource',
+                'class' => 'yii\i18n\PhpMessageSource',
                 'basePath' => __DIR__ . '/messages',
             ];
         }
@@ -42,9 +42,10 @@ class Bootstrap implements BootstrapInterface
             $authManager = $app->get('authManager', false);
 
             if (!$authManager) {
-                $app->set('authManager', [
-                    'class' => DbManager::className(),
-                ]);
+                $attributes = get_object_vars($app->get('authManager'));
+                $app->set('authManager', DbManager::className());
+                foreach ($attributes as $key => $value)
+                    $app->authManager->$key = $value;
             } else if (!($authManager instanceof ManagerInterface)) {
                 throw new InvalidConfigException('You have wrong authManager configuration');
             }
@@ -52,10 +53,10 @@ class Bootstrap implements BootstrapInterface
             // if dektrium/user extension is installed, copy admin list from there
             if ($this->checkUserModuleInstalled($app) && $app instanceof WebApplication) {
                 $app->getModule('rbac')->admins = $app->getModule('user')->admins;
-            }   
+            }
         }
     }
-    
+
     /**
      * Verifies that dektrium/yii2-rbac is installed and configured.
      * @param  Application $app
@@ -69,7 +70,7 @@ class Bootstrap implements BootstrapInterface
             return $app->hasModule('rbac') && $app->getModule('rbac') instanceof RbacConsoleModule;
         }
     }
-    
+
     /**
      * Verifies that dektrium/yii2-user is installed and configured.
      * @param  Application $app
@@ -79,7 +80,7 @@ class Bootstrap implements BootstrapInterface
     {
         return $app->hasModule('user') && $app->getModule('user') instanceof UserModule;
     }
-    
+
     /**
      * Verifies that authManager component is configured.
      * @param  Application $app

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,11 +21,16 @@ $ composer require dektrium/yii2-rbac:1.0.0-alpha@dev
 Add rbac module to web application config file as follows:
 
 ```php
+'components' => [
+    'authManager' => [
+        'class' => 'dektrium\rbac\components\DbManager',
+        'cache' => 'yii\caching\FileCache', // optional
+    ],
 ...
-'modules' => [
-    ...
-    'rbac' => 'dektrium\rbac\RbacWebModule',
-    ...
+    'modules' => [
+        ...
+        'rbac' => 'dektrium\rbac\RbacWebModule',
+        ...
 ],
 ...
 ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    | no
| Tests pass?   | NA

When initializing the components\DbManger of yii2-rbac
existing configuration like 'cache' or 'cacheKey' gets
overridden. Using Cached RBAC is currently not possible
in yii2-rbac without this fix.